### PR TITLE
Show error message on excpetion and run request in a different thread

### DIFF
--- a/src/gimp-stable-boy/gimp-stable-boy.py
+++ b/src/gimp-stable-boy/gimp-stable-boy.py
@@ -239,6 +239,9 @@ def api_request_from_gimp_params(**kwargs):
         gimp.progress_update(percent_time_spent_until_timeout)
         if time_spent > REQUEST_TIMEOUT_SECONDS:
             raise Exception('Timeout waiting server.')
+        if hasattr(t, 'request_error'):
+            t.join()
+            raise t.request_error
 
     t.join()
     if hasattr(t, 'request_error'):

--- a/src/gimp-stable-boy/gimp-stable-boy.py
+++ b/src/gimp-stable-boy/gimp-stable-boy.py
@@ -246,9 +246,8 @@ def run(*args, **kwargs):
     img = kwargs['image']
     try:
         x, y, width, height = determine_active_area(kwargs['image'], kwargs['autofit_inpainting'])
-        sd_request = create_api_request_from_gimp_params(x=x, y=y, width=width, height=height, **kwargs)
         gimp.progress_init('Waiting for server')
-        sd_result = api_request_from_gimp_params(**kwargs)
+        sd_result = api_request_from_gimp_params(x=x, y=y, width=width, height=height, **kwargs)
         
         if kwargs['mode'] == 'EXTRAS':
             generated_images = [sd_result['image']]


### PR DESCRIPTION
# Why

On any error the OK button gets disabled and there is no way to retry.
When waiting for gimp to get the response from the server on ubuntu, a warning message keeps poping up saying the system is unresponsive.

# What

When an exception is thrown, show a dialog with the exception and return successfully. This closes the dialog.

When waiting for the request to return, run the request on a different thread and update a progress bar showing how much time passed in relation to the timeout.

Timeout is a constant: 40 seconds 

Some error messages now show on the error console that can be seen from inside gimp:

![image](https://user-images.githubusercontent.com/410600/206011242-4de0b04a-5555-4ff6-b33e-27d6fc311c7d.png)

![image](https://user-images.githubusercontent.com/410600/206011377-12a6cc4d-2d34-460f-8faa-d62a83e6a360.png)

![image](https://user-images.githubusercontent.com/410600/206011987-878eeb6f-3153-4665-86cc-a11ab2fb053b.png)



